### PR TITLE
Make sure "events-pro" is converted into  a valid variable.

### DIFF
--- a/webpack/externals/tribe/events-pro.js
+++ b/webpack/externals/tribe/events-pro.js
@@ -1,12 +1,14 @@
 const REGEX = /^@moderntribe\/events-pro\//;
 
 module.exports = function eventsProExternals( context, request, callback ) {
-	if ( REGEX.test( request ) ) {
-		const path = request
-			.replace( /\//g, '.' ) // Convert `/` to `.`
-			.replace( '@moderntribe', 'tribe' );
+    if ( REGEX.test( request ) ) {
+        const path = request
+            .replace( /\//g, '.' ) // Convert `/` to `.`
+            // Make sure tribe.events-pro is converted into an accessible property as tribe["events-pro"] instead
+            .replace( /.(\w+-\w+)/, '["$1"]' )
+            .replace( '@moderntribe', 'tribe' );
 
-		return callback( null, `var ${ path }` );
-	}
-	callback();
-};
+        return callback( null, `var ${ path }` );
+    }
+    callback();
+}


### PR DESCRIPTION
The variable created on the current implementation was an invalid dot notation variable like.

```
var tribe.events-pro.package
```

This declaration is invalid in JS world and needs to be
created using bracket notation instead like.

```
var tribe["events-pro"].package
```

Reference:

> In the object.property syntax, the property must be a valid JavaScript identifier.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors