### PR TITLE
Set filePath flag for stylelint task

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 module.exports = function( gulp ) {
+	var wrappedGulp = require( 'gulp-param' )( gulp, process.argv, 'cb' );
 	var normalizedPath = require( 'path' ).join( __dirname, 'tasks' );
 
 	require( 'fs' ).readdirSync( normalizedPath ).forEach( function( file ) {
@@ -6,10 +7,10 @@ module.exports = function( gulp ) {
 			return;
 		}
 
-		require( './tasks/' + file )( gulp );
+		require( './tasks/' + file )( wrappedGulp );
 	} );
 
 	// Gulp v4 must have tasks that are used in series() or parallel() defined first.
-	require( './tasks/default.js' )( gulp );
-	require( './tasks/package.js' )( gulp );
+	require( './tasks/default.js' )( wrappedGulp );
+	require( './tasks/package.js' )( wrappedGulp );
 };

--- a/tasks/compress-js.js
+++ b/tasks/compress-js.js
@@ -18,16 +18,16 @@ module.exports = function( gulp ) {
 			dir + '/*.js',
 			'!' + dir + '/*.min.js'
 		] )
-		.pipe( uglify().on( 'error', function( e ){
-            console.log( {
-            	filename: e.filename,
-            	line: e.line,
-            	col: e.col,
-            	name: e.name,
-            	message: e.message,
-            } );
-            return this.end();
-         } ) )
+		.pipe( uglify().on( 'error', function( e ) {
+			console.log( {
+				filename: e.filename,
+				line: e.line,
+				col: e.col,
+				name: e.name,
+				message: e.message,
+			} );
+			return this.end();
+		} ) )
 		.pipe(
 			rename( {
 				extname: '.min.js'

--- a/tasks/eslint.js
+++ b/tasks/eslint.js
@@ -1,7 +1,6 @@
-module.exports = function( originalGulp ) {
+module.exports = function( gulp ) {
 	'use-strict';
 
-	var gulp = require( 'gulp-param' )( originalGulp, process.argv );
 	var eslint = require( 'gulp-eslint' );
 
 	var task = function( filePath ) {
@@ -14,12 +13,10 @@ module.exports = function( originalGulp ) {
 			process.exit(-1);
 		}
 
-		var config = {
-			resolvePluginsRelativeTo: 'node_modules/@the-events-calendar/product-taskmaster',
-		};
-
 		return gulp.src( filePath )
-			.pipe( eslint( config ) )
+			.pipe( eslint( {
+				resolvePluginsRelativeTo: 'node_modules/@the-events-calendar/product-taskmaster',
+			} ) )
 			.pipe( eslint.format() )
 			.pipe( eslint.failAfterError() )
 	};

--- a/tasks/package.js
+++ b/tasks/package.js
@@ -6,7 +6,7 @@ module.exports = function( gulp ) {
 	// Gulp is v3.
 	if ( gulp.hasTask ) {
 		var sequence = require( 'run-sequence' ).use( gulp );
-		task = function( callback ) {
+		task = function( cb ) {
 			sequence(
 				'pull',
 				'postcss',
@@ -16,7 +16,7 @@ module.exports = function( gulp ) {
 				],
 				'webpack',
 				'zip',
-				callback
+				cb
 			);
 		};
 

--- a/tasks/postcss.js
+++ b/tasks/postcss.js
@@ -18,7 +18,7 @@ module.exports = function( gulp ) {
 			postcssImport,
 			postcssMixins,
 			postcssNested,
-			postcssPresetEnv( { stage: 0, preserve: false } ),
+			postcssPresetEnv( { stage: 0, preserve: true } ),
 			postcssInlineSvg,
 			postcssCalc,
 			postcssHexrgba,

--- a/tasks/postcss.js
+++ b/tasks/postcss.js
@@ -18,7 +18,7 @@ module.exports = function( gulp ) {
 			postcssImport,
 			postcssMixins,
 			postcssNested,
-			postcssPresetEnv( { stage: 0, preserve: true } ),
+			postcssPresetEnv( { stage: 0, preserve: false } ),
 			postcssInlineSvg,
 			postcssCalc,
 			postcssHexrgba,

--- a/tasks/stylelint.js
+++ b/tasks/stylelint.js
@@ -1,18 +1,27 @@
-module.exports = function( gulp ) {
+module.exports = function( originalGulp ) {
 	'use-strict';
 
+	var gulp = require( 'gulp-param' )( originalGulp, process.argv );
 	var stylelint = require( 'gulp-stylelint' );
-	var postcss_dir = './src/resources/postcss'
+	// var postcss_dir = './src/resources/postcss';
 
-	var task = function() {
-		return gulp.src( postcss_dir + '/**/*.pcss' )
+	var task = function( filePath ) {
+		// --filePath flag is either string or array and must be provided.
+		if (
+			! Array.isArray( filePath ) &&
+			( typeof filePath !== 'string' || ! filePath )
+		) {
+			console.error( 'At least one path using the `--filePath` flag must be provided' );
+			process.exit(-1);
+		}
+
+		return gulp.src( filePath )
 			.pipe( stylelint( {
 				fix: false,
 				reporters: [
 					{ formatter: 'string', console: true },
 				],
-			} ) )
-			.pipe( gulp.dest( postcss_dir ) );
+			} ) );
 	};
 
 	gulp.task( 'stylelint', task );

--- a/tasks/stylelint.js
+++ b/tasks/stylelint.js
@@ -1,9 +1,7 @@
-module.exports = function( originalGulp ) {
+module.exports = function( gulp ) {
 	'use-strict';
 
-	var gulp = require( 'gulp-param' )( originalGulp, process.argv );
 	var stylelint = require( 'gulp-stylelint' );
-	// var postcss_dir = './src/resources/postcss';
 
 	var task = function( filePath ) {
 		// --filePath flag is either string or array and must be provided.


### PR DESCRIPTION
**Ticket:** N/A

This sets the `--filePath` flag for stylelint so that users of the stylelint task can define their own path to lint.

**Artifact:**

![image](https://user-images.githubusercontent.com/16699941/122339948-3fe41400-cf74-11eb-8575-258c461ac98f.png)
