### PR TITLE
Set preserve only for custom properties

### DIFF
--- a/tasks/postcss.js
+++ b/tasks/postcss.js
@@ -22,10 +22,9 @@ module.exports = function( gulp ) {
 			postcssNested,
 			postcssPresetEnv( {
 				stage: 0,
-				preserve: preserveFlag,
 				feature: {
-					'custom-media-queries': {
-						preserve: false,
+					'custom-properties': {
+						preserve: preserveFlag,
 					},
 				},
 			} ),

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -50,7 +50,14 @@ module.exports = function( gulp ) {
 					postcssImport,
 					postcssMixins,
 					postcssNested,
-					postcssPresetEnv( { stage: 0, preserve: preserveFlag } ),
+					postcssPresetEnv( {
+						stage: 0,
+						feature: {
+							'custom-properties': {
+								preserve: preserveFlag,
+							},
+						},
+					} ),
 					postcssInlineSvg,
 					postcssCalc,
 					postcssHexrgba,


### PR DESCRIPTION
**Ticket:** N/A

This PR sets the preserve flag only for custom properties, so that none of the other plugins preserve their pre-compiled styles.

**Artifact:** N/A