### PR TITLE
Bump all versions to 2.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ that in a repository, first ensure you are running node 16 and npm 7
 following command:
 
 ```
-npm install --save-dev @the-events-calendar/product-taskmaster@^2.2.0
+npm install --save-dev @the-events-calendar/product-taskmaster@^2.2.1
 ```
 
 or add the following to the `package.json` in the `devDependencies` section:
 
 ```
-"product-taskmaster": "@the-events-calendar/product-taskmaster@^2.2.0",
+"product-taskmaster": "@the-events-calendar/product-taskmaster@^2.2.1",
 ```
 
 ### Browserslist
@@ -201,7 +201,7 @@ An example might look like:
 
 #### eslint
 
-This task runs ESLint on the JavaScript files using our ESLint configurations. Add an 
+This task runs ESLint on the JavaScript files using our ESLint configurations. Add an
 `.eslintrc` file in the working repository and extend one of the configurations.
 A relative path from the `.eslintrc` file is required as Product Taskmaster is not
 a standard ESLint configuration package:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@the-events-calendar/product-taskmaster",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@the-events-calendar/product-taskmaster",
-      "version": "2.0.1",
+      "version": "2.2.1",
       "dependencies": {
         "@babel/eslint-parser": "^7.14.5",
         "ansi-colors": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@the-events-calendar/product-taskmaster",
   "description": "This is a collection of The Events Calendar product Gulp tasks",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "repository": "git@github.com:the-events-calendar/product-taskmaster.git",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Trying to figure out why the latest isn't getting pulled via `npm install`