### PR TITLE
Ignore `property-no-unknown` rule on `container-type` property

### DIFF
--- a/config/stylelint.js
+++ b/config/stylelint.js
@@ -38,7 +38,9 @@ module.exports = {
 		'no-extra-semicolons': true,
 		'no-invalid-double-slash-comments': null,
 		'order/properties-alphabetical-order': true,
-		'property-no-unknown': true,
+		'property-no-unknown': [ true, {
+			'ignoreProperties': [ 'container-type' ]
+		} ],
 		'rule-empty-line-before': [ 'always-multi-line', {
 			'ignore': [ 'after-comment', 'first-nested' ]
 		} ],


### PR DESCRIPTION
In ET, we are explicitly ignoring the `container-type` property for the `property-no-unknown` rule. I think it would be good to make this global.