### PR TITLE
Cross-platform paths in Webpack directory utils

### DIFF
--- a/webpack/utils/directories.js
+++ b/webpack/utils/directories.js
@@ -1,14 +1,12 @@
 const { lstatSync, readdirSync } = require( 'fs' );
-const { join } = require( 'path' );
+const { basename, join } = require( 'path' );
 
 const isDirectory = source => lstatSync( source ).isDirectory();
 const getDirectories = source => (
 	readdirSync( source ).map( name => join( source, name ) ).filter( isDirectory )
 );
 const getDirectoryNames = source => (
-	getDirectories( source ).map( file => {
-		return file.replace( /^.*\//, '' );
-	} )
+	getDirectories( source ).map( file => basename( file ) )
 );
 
 module.exports = { getDirectories, getDirectoryNames };


### PR DESCRIPTION
### Context: ###
In the `directories.js` utility for Webpack, the `getDirectoryNames` function retrieves the names of directories out of their full paths by removing everything before and including the last `/` (path separator).

### Problem: ###
On Windows, paths use backslashes (`\`), not forward slashes (`/`). The regex `/^.*\//` is looking to match `/`, that doesn’t exist in Windows paths. This utility fails in Windows, breaking the Webpack build process in our plugins.

### Fix: ###
Instead of relying on a regex, we can use Node's `path.basename` to handle both Windows and UNIX-like systems. The `basename` function is platform-agnostic and will extract the correct directory name in all environments.