### PR TITLE
[ET-2293] Remove Moment from vendor.js

### DIFF
--- a/webpack/externals/vendor.js
+++ b/webpack/externals/vendor.js
@@ -1,5 +1,4 @@
 const vendor = {
-	moment: 'moment',
 	react: 'React',
 	'react-dom': 'ReactDOM',
 	'regenerator-runtime/runtime': 'regeneratorRuntime',


### PR DESCRIPTION
[ET-2293](https://stellarwp.atlassian.net/browse/ET-2293)

This fixes an issue that was occurring in ET https://github.com/the-events-calendar/event-tickets/pull/3533

This issue mainly occurred on versions of WordPress lower than 7.2. When you would edit an event on the block editor that contained the ticket block using ET 5.18, and then update ET to 5.19 and edit the same event, the block would throw an error.

```
Uncaught TypeError: modules[moduleId] is undefined
    __webpack_require__ https://optimistic-rook-b2a876.instawp.xyz/wp-content/plugins/event-tickets/build/Tickets/Blocks/Ticket/editor.js?ver=6.5.2:80
```

Upon trying different scenarios, we were able to find out that `moment` was being loaded as an external dependency due to Taskmaster. By removing the requirement for `moment` here that fixes the issue in ET.

[ET-2293]: https://stellarwp.atlassian.net/browse/ET-2293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ